### PR TITLE
Add support for importing 2D RZ embedded boundaries as WKT files

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2461,14 +2461,17 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
         stl_reverse_normal=False,
         potential=None,
         cover_multiple_cuts=None,
+        wkt_file=None,
         **kw,
     ):
-        assert stl_file is None or implicit_function is None, Exception(
-            "Only one between implicit_function and " "stl_file can be specified"
-        )
+        assert sum(x is not None
+                   for x in [stl_file, implicit_function, wkt_file]
+                   ) == 1, Exception('One between implicit_function, '
+                                'stl_file and wkt_file can be specified')
 
         self.implicit_function = implicit_function
         self.stl_file = stl_file
+        self.wkt_file = wkt_file
 
         if stl_file is None:
             assert stl_scale is None, Exception(
@@ -2522,6 +2525,9 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
             pywarpx.eb2.stl_reverse_normal = self.stl_reverse_normal
 
         pywarpx.eb2.cover_multiple_cuts = self.cover_multiple_cuts
+
+        if self.wkt_file is not None:
+            pywarpx.warpx.wkt_file = self.wkt_file
 
         if self.potential is not None:
             expression = pywarpx.my_constants.mangle_expression(

--- a/Source/EmbeddedBoundary/CMakeLists.txt
+++ b/Source/EmbeddedBoundary/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Boost 1.66.0 COMPONENTS headers)
+
 foreach(D IN LISTS WarpX_DIMS)
     warpx_set_suffix_dims(SD ${D})
     target_sources(lib_${SD}
@@ -7,5 +9,6 @@ foreach(D IN LISTS WarpX_DIMS)
         WarpXFaceExtensions.cpp
         WarpXFaceInfoBox.H
         Enabled.cpp
+        PolygonXYIF.H
     )
 endforeach()

--- a/Source/EmbeddedBoundary/PolygonXYIF.H
+++ b/Source/EmbeddedBoundary/PolygonXYIF.H
@@ -1,0 +1,159 @@
+#ifndef WARPX_SOURCE_EMBEDDEDBOUNDARY_WARPXPOLYGONIF_H
+#define WARPX_SOURCE_EMBEDDEDBOUNDARY_WARPXPOLYGONIF_H
+
+#include "WarpX.H"
+
+#include <AMReX_Array.H>
+#include <AMReX_Vector.H>
+#include <AMReX_EB2_IF_Base.H>
+
+#include <cmath>
+#include <algorithm>
+#include <regex>
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
+
+typedef boost::geometry::model::d2::point_xy<amrex::Real> point_t;
+typedef boost::geometry::model::polygon<point_t> polygon_t;
+typedef boost::geometry::model::multi_polygon<polygon_t> mpolygon_t;
+
+namespace
+{
+    // For all implicit functions, >0: body; =0: boundary; <0: fluid
+
+    inline void add_jump(std::vector<amrex::Real> &r, std::vector<amrex::Real> &z, std::vector<size_t> &jumps)
+    {
+        if (jumps.size() > 0 && jumps[jumps.size() - 1] == r.size() - 1)
+        {
+            r.pop_back();
+            z.pop_back();
+        }
+        else
+        {
+            jumps.push_back(r.size());
+        }
+    }
+
+    template <typename T>
+    inline void expand_ring(const T &polygon, std::vector<amrex::Real> &r, std::vector<amrex::Real> &z, std::vector<size_t> &jumps)
+    {
+        for (auto p : polygon)
+        {
+            if (p.x() == 0 && r[r.size() - 1] == 0)
+                add_jump(r, z, jumps);
+            r.push_back(p.x());
+            z.push_back(p.y());
+        }
+        add_jump(r, z, jumps);
+    }
+
+    void expand_multipolygon(const mpolygon_t &multipolygon, std::vector<amrex::Real> &r, std::vector<amrex::Real> &z, std::vector<size_t> &jumps)
+    {
+        for (auto polygon : multipolygon)
+        {
+            expand_ring(polygon.outer(), r, z, jumps);
+            for (auto ring : polygon.inners())
+                expand_ring(ring, r, z, jumps);
+        }
+    }
+
+    void parse_multipolygon(const std::string &wkt, std::vector<amrex::Real> &r, std::vector<amrex::Real> &z, std::vector<size_t> &jumps) {
+        mpolygon_t multipolygon;
+
+        boost::geometry::read_wkt(wkt, multipolygon);
+
+        expand_multipolygon(multipolygon, r, z, jumps);
+    }
+
+    class PolygonXYIF
+        : public amrex::GPUable
+    {
+    public:
+        PolygonXYIF(amrex::Real* r, amrex::Real *z, size_t n, size_t *jumps, size_t n_jumps)
+            : m_r(r),
+              m_z(z),
+              m_n(n),
+              m_jumps(jumps),
+              m_n_jumps(n_jumps)
+        {
+        }
+
+        ~PolygonXYIF() {}
+
+        PolygonXYIF(const PolygonXYIF &rhs) noexcept = default;
+        PolygonXYIF(PolygonXYIF &&rhs) noexcept = default;
+        PolygonXYIF &operator=(const PolygonXYIF &rhs) = delete;
+        PolygonXYIF &operator=(PolygonXYIF &&rhs) = delete;
+
+        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+        amrex::Real
+        operator()(AMREX_D_DECL(amrex::Real x, amrex::Real y, amrex::Real z))
+            const noexcept
+        {
+            amrex::Real dist = 1;
+
+            size_t i_jump = 0;
+
+            for (size_t i = 0; i < m_n - 1; i++) {
+                if(i_jump < m_n_jumps && m_jumps[i_jump] == i+1) {
+                    i_jump++;
+                    continue;
+                }
+                dist *= intersects_outwards(x, y, i);
+            }
+
+            return dist;
+        }
+
+        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+        amrex::Real
+        operator()(const amrex::RealArray &p) const noexcept
+        {
+            return this->operator()(AMREX_D_DECL(p[0], p[1], p[2]));
+        }
+
+    protected:
+        amrex::Real *m_r;
+        amrex::Real *m_z;
+        size_t m_n;
+
+        size_t *m_jumps;
+        size_t m_n_jumps;
+
+        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+            amrex::Real
+            intersects_outwards(amrex::Real r, amrex::Real z, int i) const noexcept
+        {
+            // Determine if the point is radially inside the line segment from curve[lineseg_i] to curve[lineseg_i+1].
+
+            if (m_r[i] <= r && m_r[i + 1] <= r)                                // point is completely outside the linesegment
+                return 1;                                                      // not inside
+            if (m_z[i] < z && m_z[i + 1] < z)                                  // point is completely above the linesegment
+                return 1;                                                      // not inside
+            if (m_z[i] >= z && m_z[i + 1] >= z)                                // point is completely below the linesegment
+                return 1;                                                      // not inside
+            if (m_r[i] > r && m_r[i + 1] > r && m_z[i] < z && z <= m_z[i + 1]) // point is completely inside the linesegment
+                return -1;                                                     // inside
+
+            // no clear bounding box decision can be made. Check for real if the point lies to the left or right of the line segment
+
+            auto p_minus_a_r = r - m_r[i];
+            auto p_minus_a_z = z - m_z[i];
+            auto b_minus_a_r = m_r[i + 1] - m_r[i];
+            auto b_minus_a_z = m_z[i + 1] - m_z[i];
+
+            // check the sign of the third component of the cross product of (p-a) x (b-a)
+
+            auto cross = (p_minus_a_r * b_minus_a_z) - (p_minus_a_z * b_minus_a_r);
+            if (m_z[i] < m_z[i + 1])
+                return cross;
+            else
+                return -cross;
+        }
+    };
+}
+
+#endif

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -12,6 +12,7 @@
 #  include "Fields.H"
 #  include "Utils/Parser/ParserUtils.H"
 #  include "Utils/TextMsg.H"
+#  include "PolygonXYIF.H"
 
 #  include <AMReX.H>
 #  include <AMReX_Array.H>
@@ -22,6 +23,7 @@
 #  include <AMReX_BoxList.H>
 #  include <AMReX_Config.H>
 #  include <AMReX_EB2.H>
+#  include <AMReX_EB2_IF.H>
 #  include <AMReX_EB_utils.H>
 #  include <AMReX_FabArray.H>
 #  include <AMReX_FabFactory.H>
@@ -100,6 +102,9 @@ WarpX::InitEB ()
     const amrex::ParmParse pp_warpx("warpx");
     std::string impf;
     pp_warpx.query("eb_implicit_function", impf);
+    std::string wkt_file;
+    pp_warpx.query("wkt_file", wkt_file);
+
     if (! impf.empty()) {
         auto eb_if_parser = utils::parser::makeParser(impf, {"x", "y", "z"});
         ParserIF const pif(eb_if_parser.compile<3>());
@@ -110,6 +115,40 @@ WarpX::InitEB ()
          // number (e.g., maxLevel()+20) for multigrid solvers.  Because the coarse
          // level has only 1/8 of the cells on the fine level, the memory usage should
          // not be an issue.
+        amrex::EB2::Build(gshop, Geom(maxLevel()), maxLevel(), maxLevel()+20);
+    } else if(!wkt_file.empty()) {
+        std::ifstream wkt_multipolygon_file(wkt_file);
+        std::string wkt_multipolygon(std::istreambuf_iterator<char>{wkt_multipolygon_file}, {});
+
+        amrex::Vector<amrex::Real> r_vec(0), z_vec(0);
+        amrex::Vector<size_t> jump_vec(0);
+        parse_multipolygon(wkt_multipolygon, r_vec, z_vec, jump_vec);
+
+        amrex::Real *r_data, *z_data;
+        size_t *jump_data;
+
+#ifdef AMREX_USE_GPU
+        amrex::Gpu::DeviceVector<amrex::Real> r_gpuvec(r_vec.size());
+        amrex::Gpu::DeviceVector<amrex::Real> z_gpuvec(z_vec.size());
+        amrex::Gpu::DeviceVector<size_t> jump_gpuvec(jump_vec.size());
+        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, r_vec.begin(), r_vec.end(), r_gpuvec.begin());
+        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, z_vec.begin(), z_vec.end(), z_gpuvec.begin());
+        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, jump_vec.begin(), jump_vec.end(), jump_gpuvec.begin());
+        amrex::Gpu::synchronize();
+        r_data = r_gpuvec.data();
+        z_data = z_gpuvec.data();
+        jump_data = jump_gpuvec.data();
+#else
+        r_data = r_vec.data();
+        z_data = z_vec.data();
+        jump_data = z_vec.data();
+#endif
+
+        PolygonXYIF polygonXY(r_data, z_data, r_vec.size(), jump_data, jump_vec.size());
+        auto latheif = amrex::EB2::lathe(polygonXY);
+
+        auto gshop = amrex::EB2::makeShop(latheif, polygonXY);
+
         amrex::EB2::Build(gshop, Geom(maxLevel()), maxLevel(), maxLevel()+20);
     } else {
         amrex::ParmParse pp_eb2("eb2");


### PR DESCRIPTION
This PR adds support for using 2D [WKT files](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) as volumes of revolution for embedded boundaries. The WKT format was chosen mostly because it is fairly simple, and boost::geometry (which is already used) contains a parser for it.